### PR TITLE
Increase maximum request length

### DIFF
--- a/server-override/etc/jetty.xml
+++ b/server-override/etc/jetty.xml
@@ -61,7 +61,7 @@
     <Set name="securePort"><Property name="solr.jetty.secure.port" default="8443" /></Set>
     <Set name="outputBufferSize"><Property name="solr.jetty.output.buffer.size" default="32768" /></Set>
     <Set name="outputAggregationSize"><Property name="solr.jetty.output.aggregation.size" default="8192" /></Set>
-    <Set name="requestHeaderSize"><Property name="solr.jetty.request.header.size" default="8192" /></Set>
+    <Set name="requestHeaderSize"><Property name="solr.jetty.request.header.size" default="524288" /></Set>
     <Set name="responseHeaderSize"><Property name="solr.jetty.response.header.size" default="8192" /></Set>
     <Set name="sendServerVersion"><Property name="solr.jetty.send.server.version" default="false" /></Set>
     <Set name="sendDateHeader"><Property name="solr.jetty.send.date.header" default="false" /></Set>


### PR DESCRIPTION
Bumped the jetty request header size to a hefty 512kB, this increases the maximum length of the GET request for searches. This change was **already applied as a hotfix** to some instances, and was found working well.